### PR TITLE
Bad link about Providers and DI

### DIFF
--- a/src/navigation/nav-controller.ts
+++ b/src/navigation/nav-controller.ts
@@ -55,7 +55,7 @@ import { ViewController } from './view-controller';
  * Behind the scenes, when Ionic instantiates a new NavController, it creates an
  * injector with NavController bound to that instance (usually either a Nav or
  * Tab) and adds the injector to its own providers.  For more information on
- * providers and dependency injection, see [Providers and DI]().
+  providers and dependency injection, see [Providers and DI]().
  *
  * Instead, you can inject NavController and know that it is the correct
  * navigation controller for most situations (for more advanced situations, see


### PR DESCRIPTION
#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

On line 58 there is a link that's supposed to take you to a page about Providers and DI but it links to the current info page about the NavController.